### PR TITLE
Drop future dependency for Python 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -337,7 +337,7 @@ try:
             'Source': 'https://github.com/lebigot/uncertainties'
         },
 
-        install_requires=['future'],
+        install_requires=["future; python_version < '3.1'"],
 
         tests_require=['nose', 'numpy'],
         


### PR DESCRIPTION
`future` is only used by `uncertainties` to provide `builtins` imports in Python 2, so it is not needed when using `uncertainties` in Python 3. The main motivation for dropping `future` now is that it is unmaintained and has unpatched security vulnerabillties (see https://github.com/PythonCharmers/python-future/pull/610 for example). The vulnerabilities do not affect `uncertainties` but they add a hurdle to some users using `uncertainties` as they may not want to have known unpatched security vulnerabilities in their environments.

Personally, I think it would be fine to drop Python 2 support entirely but this PR makes the minimal change of just not listing `future` as a dependency when installing `uncertainties` in Python 3.