### PR TITLE
Ensure that GitHub Actions tests against the installed package

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -28,8 +28,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install -e .
-        python -m pip install pytest pytest-cov numpy
+        python -m pip install .[arrays,test]
     - name: Test source code and docs
       run: |
         pytest --cov . --cov-report xml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "uncertainties"
-version = "3.1.7"
+version = "3.2.0"
 authors = [
     {name = "Eric O. LEBIGOT (EOL)", email = "eric.lebigot@normalesup.org"},
 ]
@@ -50,7 +50,7 @@ classifiers = [
 dependencies = []
 
 [tool.setuptools.packages.find]
-include = ["uncertainties"]
+include = ["uncertainties", "uncertainties.unumpy"]
 exclude = ["doc", "test"]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,9 +49,8 @@ classifiers = [
 ]
 dependencies = []
 
-[tool.setuptools.packages.find]
-include = ["uncertainties", "uncertainties.unumpy"]
-exclude = ["doc", "test"]
+[tool.setuptools]
+packages = ["uncertainties", "uncertainties.unumpy"]
 
 [project.urls]
 Documentation = "http://uncertainties-python-package.readthedocs.io/"


### PR DESCRIPTION
PYTHONSAFEPATH=1 will prevent Python from loading the uncertainties files from the repo directory instead of loading them from site-packages (at least for Python >=3.11 when PYTHONSAFEPATH was added).

pytest's `import-mode=importlib` will prevent `pytest` from adding the working directory to the Python path.